### PR TITLE
Updated colors to make text more visible

### DIFF
--- a/src/components/AboutCard/MainCard.js
+++ b/src/components/AboutCard/MainCard.js
@@ -10,7 +10,8 @@ const useStyles = makeStyles(theme => ({
   },
   card: {
     minHeight: '628px',
-    backgroundColor: '#EEF5FF',
+    backgroundColor: '#F2F6FF',
+    color: '#1D006E',
     borderRadius: '10px',
     padding: '50px 30px'
   }

--- a/src/components/AboutCard/MainCard.js
+++ b/src/components/AboutCard/MainCard.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles(theme => ({
   card: {
     minHeight: '628px',
     backgroundColor: '#F2F6FF',
-    color: '#1D006E',
+    color: '#000000',
     borderRadius: '10px',
     padding: '50px 30px'
   }


### PR DESCRIPTION
Updated colors according to https://github.com/codeforcauseorg/codeforcause.org/blob/development/design/home_view/home_web.pdf to make text more visible,  fixes: #96

**Before:**
<img width="1429" alt="Screenshot 2020-09-25 at 1 03 50 PM" src="https://user-images.githubusercontent.com/8397274/94241111-d9c0e800-ff31-11ea-956e-37b6909eb9c3.png">

**After**
<img width="1440" alt="Screenshot 2020-09-25 at 1 20 35 PM" src="https://user-images.githubusercontent.com/8397274/94241170-ee04e500-ff31-11ea-831b-79c265e99275.png">


