### PR TITLE
Font not visible with dark theme on macbook at some places

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -47,7 +47,8 @@ const useStyles = makeStyles(() =>
       body: {
         height: '100%',
         width: '100%',
-        overflow: 'hidden'
+        overflow: 'hidden',
+        color: '#000'
       },
       '#root': {
         height: '100%',

--- a/src/views/pages/CLView/StandFor.js
+++ b/src/views/pages/CLView/StandFor.js
@@ -13,6 +13,7 @@ import {
 
 const useStyles = makeStyles(theme => ({
   root: {
+    color: '#000',
     background: '#FFF',
     paddingTop: 80,
     paddingBottom: 80,


### PR DESCRIPTION
With dark mode theme, font is not visible where it is explicitily not set.
![img](https://camo.githubusercontent.com/1f5d1b5a4a63d486dd723cf9d460e255f70b1b0f/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f5557656a766a315a676d78786f4570767a4c2f67697068792e676966)