### PR TITLE
disable myProfile button

### DIFF
--- a/src/layouts/MainLayout/TopBar/Account.js
+++ b/src/layouts/MainLayout/TopBar/Account.js
@@ -14,7 +14,6 @@ import {
   makeStyles
 } from '@material-ui/core';
 import { login, dismissLogin, logout } from 'src/actions/accountActions';
-import { Link } from 'react-router-dom';
 
 const useStyles = makeStyles(theme => ({
   button: {
@@ -142,14 +141,15 @@ function Account() {
           onClose={handleCloseMenu}
         >
           <MenuItem onClick={handleLogout}>Logout</MenuItem>
-          <MenuItem onClick={handleCloseMenu}>
+          {/* This shortcut to Profile will be activated once things are fully complete with Profile */}
+          {/* <MenuItem onClick={handleCloseMenu}>
             <Link
               to="/student"
               style={{ textDecoration: 'none', color: 'black' }}
             >
               My Profile
             </Link>
-          </MenuItem>
+          </MenuItem> */}
         </Menu>
       </div>
     </div>


### PR DESCRIPTION
https://codeforcause.org/
Main website is showing profile: 
![image](https://user-images.githubusercontent.com/48255244/95092688-92aed000-0745-11eb-9c1f-8d4006f0d146.png)
which goes to page which is under development(where things are hardcoded), so removing that shortcut untill the page gets out of development phase and ready to serve in production.
