### PR TITLE
Fix Node Modules Error

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,5 +2,6 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
In Current version this error is giving.
![image](https://user-images.githubusercontent.com/43095489/106235794-a1098600-6225-11eb-948c-8eba5551e31c.png)
This is the fix of the issue #205 . I have exclude the node_module from the `jsconfig.json` file