### PR TITLE
fixed the FAQ section of Elastic weekend + Hackathon page typo in the last question

### DIFF
--- a/src/data/events/hackathons/elastic.js
+++ b/src/data/events/hackathons/elastic.js
@@ -149,7 +149,7 @@ export const elastic = {
     {
       title: 'What if I want to learn but do not want to take part in hackathon?',
       answer:
-        `Don't worry. Register for event. You will get notified for all the sessions. You can skip Hackathon if uou don't feel ready yet.`
+        `Don't worry. Register for event. You will get notified for all the sessions. You can skip Hackathon if you don't feel ready yet.`
     },
   ]
 };


### PR DESCRIPTION
Description:
There was a type error of 'uou' instead of 'you' in thr FAQ section of Elastic weekend in the last question.

Changes Made:
Fixed the 'uou' typo to 'you'

** Before **
![Screenshot from 2021-05-20 19-26-10](https://user-images.githubusercontent.com/58226527/118992552-5feadc80-b9a2-11eb-8dfd-f73141dac578.jpg)

** After **
![Screenshot from 2021-05-20 19-26-55](https://user-images.githubusercontent.com/58226527/118992673-785af700-b9a2-11eb-9eeb-ce466890be24.jpg)
 
